### PR TITLE
Adding PHP 5.6 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer install --dev --prefer-source


### PR DESCRIPTION
We probably ought to support PHP 5.6.
