### PR TITLE
Update all Eloqua URLs.

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -12,7 +12,7 @@ $client->authenticate($site, $login, $password, $baseUrl);
 `$site` is the name of the Eloqua instance to which you are authenticating; it's
 often a variation on the name of your company. `$login` and `$password` should
 be self-explanatory.  `$baseUrl` is your Eloqua endpoint URL, it is optional.  If
-`$baseUrl` is excluded, https://secure.eloqua.com will be used.
+`$baseUrl` is excluded, https://secure.p01.eloqua.com will be used.
 
 After executing the `$client->authenticate($site, $login, $password);` method
 using correct credentials, all further requests are done as the given user.

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ class Client
    * @var array
    */
   private $options = array(
-    'base_url' => 'https://secure.eloqua.com/API/REST',
+    'base_url' => 'https://secure.p01.eloqua.com/API/REST',
     'version' => '2.0',
     'user_agent' => 'Elomentary (http://github.com/tableau-mkt/elomentary)',
     'timeout' => 10,

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -23,7 +23,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class HttpClient implements HttpClientInterface {
   protected $options = array(
-    'base_url' => 'https://secure.eloqua.com/API/REST',
+    'base_url' => 'https://secure.p01.eloqua.com/API/REST',
     'version' => '2.0',
     'user_agent' => 'Elomentary (http://github.com/tableau-mkt/elomentary)',
     'timeout' => 10,

--- a/test/src/Api/AbstractApiTest.php
+++ b/test/src/Api/AbstractApiTest.php
@@ -195,8 +195,8 @@ class AbstractApiTest extends \PHPUnit_Framework_TestCase {
 
   public function baseUrlTestProvider() {
     return array (
-      array ('Eloqua\Api\AbstractApi', 'https://secure.eloqua.com/API/REST'),
-      array ('Eloqua\Api\AbstractBulkApi', 'https://secure.eloqua.com/API/bulk'),
+      array ('Eloqua\Api\AbstractApi', 'https://secure.p01.eloqua.com/API/REST'),
+      array ('Eloqua\Api\AbstractBulkApi', 'https://secure.p01.eloqua.com/API/bulk'),
     );
   }
 

--- a/test/src/ClientTest.php
+++ b/test/src/ClientTest.php
@@ -45,8 +45,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
   public function getAuthenticationData() {
     return array(
       array('My.Company', 'My.Login', 'Battery.Horse.Staple'),
-      array('My.Company', 'My.Login', 'Battery.Horse.Staple', 'https://secure.eloqua.com/API/REST'),
-      array('My.Company', 'My.Login', 'Battery.Horse.Staple', 'https://secure.eloqua.com/API/REST', '1.0'),
+      array('My.Company', 'My.Login', 'Battery.Horse.Staple', 'https://secure.p01.eloqua.com/API/REST'),
+      array('My.Company', 'My.Login', 'Battery.Horse.Staple', 'https://secure.p01.eloqua.com/API/REST', '1.0'),
     );
   }
 

--- a/test/src/HttpClient/HttpClientTest.php
+++ b/test/src/HttpClient/HttpClientTest.php
@@ -24,7 +24,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase {
 
     $options = $this->getPrivateProperty('Eloqua\HttpClient\HttpClient', 'options')->getValue($httpClient);
     $this->assertEquals(33, $options['timeout']);
-    $this->assertEquals('https://secure.eloqua.com/API/REST', $options['base_url']);
+    $this->assertEquals('https://secure.p01.eloqua.com/API/REST', $options['base_url']);
   }
 
   /**


### PR DESCRIPTION
## What? Why?
Oracle is depreciating the old PODless URLs. This will update all to the new set.

Changes to default URL settings.

Closes #52 