### PR TITLE
Add pagination functionality to Bulk Download Function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
 
 env:
   global:

--- a/src/Api/AbstractBulkApi.php
+++ b/src/Api/AbstractBulkApi.php
@@ -204,7 +204,7 @@ abstract class AbstractBulkApi extends AbstractApi {
 
     if (isset($limit) && isset($offset) && $limit > 0 && $offset >= 0){
       return $this->get("$uri/data?limit=$limit?offset=$offset");
-    } elseif (isset($limit) && !isset($offset) && $limit > 0)) {
+    } elseif (isset($limit) && !isset($offset) && $limit > 0) {
       return $this->get("$uri/data?limit=$limit");
     } else {
       return $this->get("$uri/data");

--- a/src/Api/AbstractBulkApi.php
+++ b/src/Api/AbstractBulkApi.php
@@ -206,6 +206,8 @@ abstract class AbstractBulkApi extends AbstractApi {
       return $this->get("$uri/data?limit=$limit?offset=$offset");
     } elseif (isset($limit) && !isset($offset) && $limit > 0) {
       return $this->get("$uri/data?limit=$limit");
+    } elseif (!isset($limit) && isset($offset) && $offset >= 0) {
+      return $this->get("$uri/data?offset=$offset");      
     } else {
       return $this->get("$uri/data");
     }  

--- a/src/Api/AbstractBulkApi.php
+++ b/src/Api/AbstractBulkApi.php
@@ -187,18 +187,18 @@ abstract class AbstractBulkApi extends AbstractApi {
    * @param integer $limit
    *   A URL parameter that specifies the maximum number of records to return. 
    *   This can be any positive integer between 1 and 50000 inclusive.
-   *   If not specified, the default is 1000.
+   *   If not specified, eloqua will automatically default to 1000.
    *
    * @param integer $offset
    *   Specifies an offset that allows you to retrieve the next batch of records.
    *   For example, if your limit is 1000, specifying an offset of 1000 will return
-   *   records 1000 through 2000. If not specified, the default is 0.
+   *   records 1000 through 2000. If not specified, eloqua will automatically default to 0.
    *   (Any positive integer).
    * 
    * @return array
    *   Download response, including records matched from mapping() call.
    */
-  public function download($limit = null, $offset = null, $statusResponse = null) {
+  public function download($statusResponse = null, $limit = null, $offset = null) {
     $statusResponse = $this->getResponse('status', $statusResponse);
     $uri = trim($statusResponse['syncedInstanceUri'], '/');
 

--- a/src/Api/AbstractBulkApi.php
+++ b/src/Api/AbstractBulkApi.php
@@ -178,20 +178,37 @@ abstract class AbstractBulkApi extends AbstractApi {
   }
 
   /**
-   * Downloads a file from the staging area.
+   * Retrieves data from the staging area.
    *
    * @param array $statusResponse
    *   Response from $this->status call.  Defaults to last $this->status()
    *   response.
    *
+   * @param integer $limit
+   *   A URL parameter that specifies the maximum number of records to return. 
+   *   This can be any positive integer between 1 and 50000 inclusive.
+   *   If not specified, the default is 1000.
+   *
+   * @param integer $offset
+   *   Specifies an offset that allows you to retrieve the next batch of records.
+   *   For example, if your limit is 1000, specifying an offset of 1000 will return
+   *   records 1000 through 2000. If not specified, the default is 0.
+   *   (Any positive integer).
+   * 
    * @return array
    *   Download response, including records matched from mapping() call.
    */
-  public function download($statusResponse = null) {
+  public function download($limit = null, $offset = null, $statusResponse = null) {
     $statusResponse = $this->getResponse('status', $statusResponse);
     $uri = trim($statusResponse['syncedInstanceUri'], '/');
 
-    return $this->get("$uri/data");
+    if (isset($limit) && isset($offset) && $limit > 0 && $offset >= 0){
+      return $this->get("$uri/data?limit=$limit?offset=$offset");
+    } elseif (isset($limit) && !isset($offset) && $limit > 0)) {
+      return $this->get("$uri/data?limit=$limit");
+    } else {
+      return $this->get("$uri/data");
+    }  
   }
 
   /**


### PR DESCRIPTION
## What? Why?
Elomentary's existing Bulk API download functionality is limited to only pulling the first 1000 records from an export in the staging area. In order to pull down more than those first 1000 records, it must support pagination via LIMIT and OFFSET.

## Developer Notes
I attempted to minimize the footprint of this update as much as possible by making the two pagination fields optional -- along with including a strict validation structure to ensure the correct GET requests are made depending on the arguments passed into the function. 